### PR TITLE
feat(phpunit): mode package (Testbench) + répertoire pcov configurable

### DIFF
--- a/.github/actions/setup-php-and-dependencies/action.yml
+++ b/.github/actions/setup-php-and-dependencies/action.yml
@@ -24,6 +24,10 @@ inputs:
     required: false
     default: "none"
     description: "Coverage driver: none, pcov, or xdebug"
+  pcov_directory:
+    required: false
+    default: "app"
+    description: "Directory pcov should instrument when coverage is pcov (e.g. src for packages)"
   extra_owner:
     required: false
     description: "Optional extra owner (organization or user) for additional private repositories"
@@ -61,7 +65,7 @@ runs:
         php-version: ${{ inputs.php-version }}
         extensions: ${{ inputs.extensions }}
         coverage: ${{ inputs.coverage }}
-        ini-values: ${{ inputs.coverage == 'pcov' && 'pcov.directory=app' || '' }}
+        ini-values: ${{ inputs.coverage == 'pcov' && format('pcov.directory={0}', inputs.pcov_directory) || '' }}
 
     - name: Cache Composer dependencies
       uses: actions/cache@v5

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,6 +19,16 @@ on:
         required: false
         type: boolean
         default: true
+      package:
+        required: false
+        type: boolean
+        default: false
+        description: "Set to true for Composer packages (Testbench): skips the Laravel env setup and runs vendor/bin/testbench package:test instead of php artisan test"
+      pcov_directory:
+        required: false
+        type: string
+        default: "app"
+        description: "Directory pcov should instrument (e.g. src for packages)"
       extra_owner:
         required: false
         type: string
@@ -43,16 +53,18 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup PHP & Composer
-        uses: Supplement-Bacon/.github/.github/actions/setup-php-and-dependencies@v2
+        uses: Supplement-Bacon/.github/.github/actions/setup-php-and-dependencies@v3
         with:
           app_id: ${{ secrets.BACKEND_CI_DEPENDENCIES_APP_ID }}
           private_key: ${{ secrets.BACKEND_CI_DEPENDENCIES_APP_PRIVATE_KEY }}
           repositories: ${{ inputs.composer_repositories }}
           coverage: pcov
+          pcov_directory: ${{ inputs.pcov_directory }}
           extra_owner: ${{ inputs.extra_owner }}
           extra_repositories: ${{ inputs.extra_repositories }}
 
       - name: Setup Laravel environment
+        if: inputs.package != true
         run: |
           cp .env.example .env
           php artisan key:generate
@@ -61,7 +73,11 @@ jobs:
         run: |
           set -o pipefail
           COVERAGE_ARGS=$(echo "${{ inputs.test-args }}" | sed -E 's/--parallel[[:space:]]*//g; s/--processes=[0-9]+[[:space:]]*//g')
-          php artisan test $COVERAGE_ARGS --coverage-clover=coverage.xml
+          if [ "${{ inputs.package }}" = "true" ]; then
+            vendor/bin/testbench package:test $COVERAGE_ARGS --coverage-clover=coverage.xml
+          else
+            php artisan test $COVERAGE_ARGS --coverage-clover=coverage.xml
+          fi
 
       - name: Upload coverage report
         if: always()
@@ -81,16 +97,18 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup PHP & Composer
-        uses: Supplement-Bacon/.github/.github/actions/setup-php-and-dependencies@v2
+        uses: Supplement-Bacon/.github/.github/actions/setup-php-and-dependencies@v3
         with:
           app_id: ${{ secrets.BACKEND_CI_DEPENDENCIES_APP_ID }}
           private_key: ${{ secrets.BACKEND_CI_DEPENDENCIES_APP_PRIVATE_KEY }}
           repositories: ${{ inputs.composer_repositories }}
           coverage: pcov
+          pcov_directory: ${{ inputs.pcov_directory }}
           extra_owner: ${{ inputs.extra_owner }}
           extra_repositories: ${{ inputs.extra_repositories }}
 
       - name: Setup Laravel environment
+        if: inputs.package != true
         run: |
           cp .env.example .env
           php artisan key:generate
@@ -100,7 +118,11 @@ jobs:
         run: |
           set -o pipefail
           COVERAGE_ARGS=$(echo "${{ inputs.test-args }}" | sed -E 's/--parallel[[:space:]]*//g; s/--processes=[0-9]+[[:space:]]*//g')
-          php artisan test $COVERAGE_ARGS --coverage-clover=coverage-base.xml
+          if [ "${{ inputs.package }}" = "true" ]; then
+            vendor/bin/testbench package:test $COVERAGE_ARGS --coverage-clover=coverage-base.xml
+          else
+            php artisan test $COVERAGE_ARGS --coverage-clover=coverage-base.xml
+          fi
 
       - name: Fallback — empty coverage file if tests crashed
         if: always()


### PR DESCRIPTION
## Contexte

Le core (`plethore-core`) rejoint l'organisation et doit utiliser le même pipeline que les APIs (tests + SonarCloud). Or `phpunit.yml` suppose une application Laravel :
- `cp .env.example .env` + `php artisan key:generate`
- `php artisan test` (la commande `test` vient de Collision, non enregistrée dans un package)
- `pcov.directory=app` codé en dur, alors que le code d'un package vit dans `src/` (couverture à 0 % sinon)

## Changements (rétro-compatibles, aucun impact sur les APIs existantes)

### `actions/setup-php-and-dependencies`
- Nouvel input optionnel `pcov_directory` (défaut : `app`) — utilisé dans `ini-values` quand `coverage: pcov`

### `workflows/phpunit.yml`
- Nouvel input `package` (booléen, défaut `false`) : saute l'étape « Setup Laravel environment » et lance `vendor/bin/testbench package:test` au lieu de `php artisan test` (mêmes arguments, même `--coverage-clover`)
- Nouvel input `pcov_directory` (défaut `app`), transmis à l'action
- Référence de l'action passée de `@v2` à `@v3` (cohérent une fois le tag `v3` re-pointé)

## Après merge

Re-pointer le tag `v3` sur `main` :
```bash
git tag -f v3 && git push origin v3 --force
```

Les valeurs par défaut sont identiques au comportement actuel — les 9 repos API ne voient aucune différence.

## Utilisation (plethore-core)

```yaml
test:
  uses: Supplement-Bacon/.github/.github/workflows/phpunit.yml@v3
  secrets: inherit
  with:
    package: true
    pcov_directory: src
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)