### PR TITLE
fix(phpunit): .env vide en mode package pour éviter les warnings Dotenv

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -64,10 +64,14 @@ jobs:
           extra_repositories: ${{ inputs.extra_repositories }}
 
       - name: Setup Laravel environment
-        if: inputs.package != true
         run: |
-          cp .env.example .env
-          php artisan key:generate
+          if [ "${{ inputs.package }}" = "true" ]; then
+            # Package (Testbench) : un .env vide suffit — évite les warnings Dotenv par test
+            [ -f .env ] || touch .env
+          else
+            cp .env.example .env
+            php artisan key:generate
+          fi
 
       - name: Run tests with coverage
         run: |
@@ -108,10 +112,14 @@ jobs:
           extra_repositories: ${{ inputs.extra_repositories }}
 
       - name: Setup Laravel environment
-        if: inputs.package != true
         run: |
-          cp .env.example .env
-          php artisan key:generate
+          if [ "${{ inputs.package }}" = "true" ]; then
+            # Package (Testbench) : un .env vide suffit — évite les warnings Dotenv par test
+            [ -f .env ] || touch .env
+          else
+            cp .env.example .env
+            php artisan key:generate
+          fi
 
       - name: Run tests with coverage on base branch
         continue-on-error: true


### PR DESCRIPTION
## Contexte

Sur `plethore-core`, chaque test affiche un warning :

```
file_get_contents(/home/runner/work/plethore-core/plethore-core/.env): Failed to open stream: No such file or directory
```

**Cause** : les tests du core bootent encore le `bootstrap/app.php` hérité du monolithe → à chaque boot, `LoadEnvironmentVariables` (phpdotenv) tente de lire `.env`, absent d'un checkout CI. Le warning est pré-existant (l'ancien CI l'avait aussi) mais le runner Collision/Testbench l'affiche, contrairement au printer PHPUnit classique → 186 warnings de bruit dans les logs.

## Changement

En mode `package`, l'étape « Setup Laravel environment » crée un `.env` vide (`touch .env`) au lieu d'être sautée. Un fichier vide ne change aucune valeur d'environnement (les `<server>` de `phpunit.xml` priment sur Dotenv) — il empêche juste le warning. Vérifié en local : 0 warning, tests verts.

Le mode app (`cp .env.example .env` + `key:generate`) est inchangé.

## Après merge

Re-pointer le tag `v3` sur `main`.

_Note : le vrai fix long terme côté core est de migrer `tests/TestCase.php` vers une TestCase Testbench native (cf. `src/Testing/PlethoreTestCase`) pour ne plus booter les vestiges du monolithe._

🤖 Generated with [Claude Code](https://claude.com/claude-code)