### PR TITLE
fix(forge): organisation requise par la Forge CLI v2

### DIFF
--- a/.github/workflows/forge.yml
+++ b/.github/workflows/forge.yml
@@ -22,6 +22,8 @@ jobs:
   forge:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    env:
+      FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -33,9 +35,11 @@ jobs:
       - name: Install Forge CLI
         run: composer global require laravel/forge-cli
 
+      - name: Switch organization
+        run: forge organization:switch ${{ secrets.FORGE_ORGANIZATION }}
+
+      - name: Switch server
+        run: forge server:switch ${{ inputs.client != '' && secrets[format('{0}_SERVER_ID', inputs.client)] || secrets.SERVER_ID }}
+
       - name: Deploy
-        run: |
-          forge server:switch ${{ inputs.client != '' && secrets[format('{0}_SERVER_ID', inputs.client)] || secrets.SERVER_ID }}
-          forge deploy ${{ inputs.client != '' && secrets[format('{0}_DOMAIN', inputs.client)] || secrets.DOMAIN }}
-        env:
-          FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
+        run: forge deploy ${{ inputs.client != '' && secrets[format('{0}_DOMAIN', inputs.client)] || secrets.DOMAIN }}

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Triggers a deployment through [Laravel Forge](https://forge.laravel.com/).
 | Secret               | Description                                                        |
 | -------------------- | ------------------------------------------------------------------ |
 | `FORGE_API_TOKEN`    | Laravel Forge API token                                            |
+| `FORGE_ORGANIZATION` | Forge organization slug used by `forge organization:switch`        |
 | `SERVER_ID`          | Forge server ID used by `forge server:switch`                      |
 | `DOMAIN`             | Default domain deployed when `client` is empty                     |
 | `<CLIENT>_DOMAIN`    | Optional client-specific domain secret (example: `P_DOMAIN`)       |
@@ -112,10 +113,13 @@ Triggers a deployment through [Laravel Forge](https://forge.laravel.com/).
 
 The deployment does:
 
-1. `forge server:switch forge server:switch ${{ inputs.client != '' && secrets[format('{0}_SERVER_ID', inputs.client)] || secrets.SERVER_ID }}`
-2. `forge deploy ${{ inputs.client != '' && secrets[format('{0}_DOMAIN', inputs.client)] || secrets.DOMAIN }}`
+1. `forge organization:switch ${{ secrets.FORGE_ORGANIZATION }}`
+2. `forge server:switch ${{ inputs.client != '' && secrets[format('{0}_SERVER_ID', inputs.client)] || secrets.SERVER_ID }}`
+3. `forge deploy ${{ inputs.client != '' && secrets[format('{0}_DOMAIN', inputs.client)] || secrets.DOMAIN }}`
 
 So if `client` is set, it uses `<CLIENT>_DOMAIN`; otherwise it falls back to `DOMAIN`. The same applies to `SERVER_ID`.
+
+> **Forge CLI v2:** the CLI is organization-scoped, so an organization must be selected (`forge organization:switch`) before switching server. Get the slug from `forge organization:list`.
 
 ### Frontend Lib CI
 
@@ -227,6 +231,7 @@ The following secrets must be configured at organization level or in the calling
 | `BACKEND_CI_DEPENDENCIES_APP_PRIVATE_KEY` | Laravel Pint, PHPUnit | GitHub App private key                  |
 | `SONAR_TOKEN`                             | SonarQube             | SonarCloud authentication token         |
 | `FORGE_API_TOKEN`                         | Deploy (Forge)        | Laravel Forge API token                 |
+| `FORGE_ORGANIZATION`                      | Deploy (Forge)        | Forge organization slug (CLI v2)        |
 | `SERVER_ID`                               | Deploy (Forge)        | Forge server ID for CLI context switch  |
 | `DOMAIN`                                  | Deploy (Forge)        | Default site domain for deploy          |
 | `<CLIENT>_DOMAIN`                         | Deploy (Forge)        | Optional client-specific site domain    |


### PR DESCRIPTION
## Contexte

Le déploiement Forge échoue depuis la mise à jour de la **Forge CLI v2** (`laravel/forge-cli ^2.0` → v2.0.2). La v2 migre vers l'API Forge v2, désormais scopée par organisation (`orgs/{slug}/servers`). Il faut donc sélectionner une organisation **avant** `server:switch`, sinon :

```
You have not selected an organization. Use the 'organization:switch' command.
```

Run en échec : https://github.com/Supplement-Bacon/table-booking-application-api/actions/runs/28543009602/job/84621483502

## Changements

- Ajout d'une étape `forge organization:switch` utilisant un nouveau secret **`FORGE_ORGANIZATION`** (le *slug* de l'organisation, cf. `forge organization:list`).
- Découpage de l'ancienne étape unique en étapes distinctes (org / server / deploy).
- `FORGE_API_TOKEN` remonté au niveau `job.env` (défini une seule fois).

## ⚠️ Action requise avant merge

1. Créer le secret d'organisation GitHub **`FORGE_ORGANIZATION`** (slug Forge), aux côtés de `FORGE_API_TOKEN`.
2. Après merge, **repointer le tag `v3`** sur le commit de merge pour que les repos consommateurs récupèrent le correctif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)