### PR TITLE
fix(model-coverage): stop perdre le rapport quand une factory manque

### DIFF
--- a/.github/workflows/model-coverage.yml
+++ b/.github/workflows/model-coverage.yml
@@ -38,15 +38,25 @@ jobs:
           extra_owner: ${{ inputs.extra_owner }}
           extra_repositories: ${{ inputs.extra_repositories }}
 
+      # The command exits non-zero as soon as a model has no factory, which is
+      # exactly when the report is worth posting. Kept in its own step so the
+      # `bash -e` abort cannot skip the capture below, and so the exit code
+      # stays readable through `steps.factory_coverage_run.outcome`.
       - name: Run Factory Coverage command
-        id: factory_coverage
+        id: factory_coverage_run
         continue-on-error: true
-        run: |
-          php vendor/bin/testbench model:factory-coverage --markdown > factory-coverage.txt
+        run: php vendor/bin/testbench model:factory-coverage --markdown > factory-coverage.txt
 
-          echo "coverage<<EOF" >> $GITHUB_OUTPUT
-          cat factory-coverage.txt >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Expose coverage report
+        id: factory_coverage
+        run: |
+          if [ ! -s factory-coverage.txt ]; then
+            echo "⚠️ The factory coverage command produced no output (outcome: ${{ steps.factory_coverage_run.outcome }}). See the job logs." > factory-coverage.txt
+          fi
+
+          echo "coverage<<EOF" >> "$GITHUB_OUTPUT"
+          cat factory-coverage.txt >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Comment PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Symptôme

Sur `plethore-core`, le commentaire de PR **Model / Factory Coverage** est vide sur toutes les PR vérifiées (274, 270, 265, 260, 250) : le titre s'affiche, le corps est vide.

## Cause

L'étape `Run Factory Coverage command` tourne sous `bash -e` (le shell par défaut des runners) et enchaîne quatre commandes, la commande PHP en premier :

```yaml
run: |
  php vendor/bin/testbench model:factory-coverage --markdown > factory-coverage.txt

  echo "coverage<<EOF" >> $GITHUB_OUTPUT
  cat factory-coverage.txt >> $GITHUB_OUTPUT
  echo "EOF" >> $GITHUB_OUTPUT
```

`model:factory-coverage` retourne `SymfonyCommand::FAILURE` dès qu'un modèle n'a pas de factory. Avec `-e`, le shell abandonne l'étape à la première ligne : **les trois écritures dans `$GITHUB_OUTPUT` ne s'exécutent jamais**. `continue-on-error: true` empêche le job d'échouer, mais ne ressuscite pas l'étape déjà morte, donc `steps.factory_coverage.outputs.coverage` est vide et le commentaire se réduit à son titre.

Extrait du log du job `factory-coverage` (run `31608997391`, `plethore-core`) :

```
shell: /usr/bin/bash -e {0}
##[error]Process completed with exit code 1.
...
message: ## 🧪 Model / Factory Coverage        <- corps vide
```

Sur `plethore-core`, `PassDeviceRegistration` n'a pas de factory depuis `7b829f74` (18/03/2026), d'où un code 1 à chaque exécution depuis cette date.

Le rapport disparaissait donc **exactement quand il avait quelque chose à signaler** : un dépôt à 100 % de couverture publiait son commentaire normalement.

## Correctif

Séparer l'exécution de la capture, plutôt que masquer le code de sortie avec un `|| true` :

- `continue-on-error` ne porte plus que sur la seule étape qui peut légitimement échouer ;
- la capture est une étape distincte, qui s'exécute donc toujours ;
- le code de sortie reste lisible via `steps.factory_coverage_run.outcome`, si le job doit un jour redevenir bloquant (il suffira de retirer `continue-on-error`) ;
- un garde-fou remplace une sortie vide par un message explicite, pour qu'un commentaire réduit à son titre ne puisse plus réapparaître silencieusement — quelle que soit la cause (`vendor/` absent, fatal PHP, commande renommée).

Aucun changement côté PHP : le code de sortie non nul est le comportement attendu d'une commande de vérification, au même titre que `pint --test` ou PHPStan.

## Vérification

Commande reproduite localement sur `plethore-core`, sortie complète et code 1 :

```
### 📊 Factory Coverage

**Coverage:** 99.25% (132/133)
...
❌ **Missing factories:**
- `PassDeviceRegistration`

exit=1
```

YAML relu par un parseur, les cinq étapes se résolvent avec les bons `id` et le `continue-on-error` sur la bonne. Je n'ai pas pu exécuter le workflow lui-même avant merge : `workflow_call` n'est déclenchable que depuis un dépôt appelant.

## À faire après merge

Le tag mobile **`v3`** doit être déplacé sur ce commit pour que les dépôts consommateurs en bénéficient — je ne l'ai pas touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)